### PR TITLE
fixes slow tests

### DIFF
--- a/src/Services/DefaultAvatar.php
+++ b/src/Services/DefaultAvatar.php
@@ -4,6 +4,7 @@ namespace LaravelEnso\Avatars\Services;
 
 use Exception;
 use Illuminate\Http\File;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\DB;
 use LaravelEnso\Avatars\Services\Generators\Gravatar;
 use LaravelEnso\Avatars\Services\Generators\Laravolt;
@@ -42,6 +43,13 @@ class DefaultAvatar
 
     private function generate(): self
     {
+        if (App::runningUnitTests()) {
+            $this->file = (new Laravolt($this->avatar))
+                ->generate();
+
+            return $this;
+        }
+
         try {
             $this->file = (new Gravatar($this->avatar))
                 ->generate();


### PR DESCRIPTION
tests are massively slowed by querying the gravatar API

With Laravolt
![image](https://user-images.githubusercontent.com/37445394/96866141-8af46880-1473-11eb-9319-34a182ade721.png)

With Gravatar
![image](https://user-images.githubusercontent.com/37445394/96866437-fb9b8500-1473-11eb-9324-48347dbd9227.png)

as you can see, the differenece in performance is more than double, almost triple.


